### PR TITLE
temporary fix before the pymongo 4 migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sqlparse==0.2.4
-pymongo>=3.2.0
+pymongo>=3.2.0,<4.0.0
 django>=2.0,<=3.1.4
 
  # requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def find_version(*file_paths):
 
 install_requires = [
     'sqlparse==0.2.4',
-    'pymongo>=3.2.0',
+    'pymongo>=3.2.0,<4.0.0',
     'django>=2.1',
 ]
 


### PR DESCRIPTION
The new version of pymongo (4.0.1) has some breaking changes. Specifically, database objects no longer support bool evaluation.
A temporary fix is to prevent the installation of the new version of pymongo (4.0.1) before the actual pymongo 4 migration.

Signed-off-by: Alessandro Bellia <casildaserrano@yahoo.it>