### PR TITLE
Update base._close for pymongo bool() eval change

### DIFF
--- a/djongo/base.py
+++ b/djongo/base.py
@@ -205,7 +205,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         """
         Closes the client connection to the database.
         """
-        if self.connection:
+        if self.connection is not None:
             with self.wrap_database_errors:
                 self.connection.client.close()
                 logger.debug('MongoClient connection closed')


### PR DESCRIPTION
With the new pymongo, the evaluation to bool has been removed. Currently, the django+djongo stack results in:

```
server              |   File "/usr/local/lib/python3.8/site-packages/django/db/backends/base/base.py", line 319, in close
server              |     self._close()
server              |   File "/usr/local/lib/python3.8/site-packages/djongo/base.py", line 208, in _close
server              |     if self.connection:
server              |   File "/usr/local/lib/python3.8/site-packages/pymongo/database.py", line 1021, in __bool__
server              |     raise NotImplementedError(
server              | NotImplementedError: Database objects do not implement truth value testing or bool(). Please compare with None instead: database is not None
``` 

This PR directly addresses the suggestion from pymongo in checking the value to `None`, rather than implicitly casting to bool. 

This is aimed at #585.