### PR TITLE
adding FlexiEmbedField.linked to #624

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a36a5392bb1e8bbc06bfaa0761e52593cf2d83b486696bf54667ba8da616c839"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
 sqlparse==0.4.2
 pymongo>=3.2.0,<4.0.0
 django>=2.0
-pytz>=2018.5
-=======
- # requirements.txt
- #
- # installs dependencies from ./setup.py, and the package itself,
- # in editable mode
- -e .
+pytz>=2018.5 


### PR DESCRIPTION
Added a EmbeddedField supported some flexible behavior. It will not be always required to put the value over the model field. If you want to skip it put null=True, blank=True. Though current implementation will check all condition and decide if the field is skippable or not. If it is possible It will skip the field from the current instance while saving in database. This functionality will give you the full feature of document type database such as mongoDB. You can save it as a flexible document.