### PR TITLE
Custom max name length

### DIFF
--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -102,7 +102,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 for table in tables]
 
     def max_name_length(self):
-        return 60
+        return self.connection.settings_dict.get('MAX_NAME_LENGTH') or 60
 
     def no_limit_value(self):
         return None


### PR DESCRIPTION
This feature is essential to be able to use Djongo on AWS with DocumentDB.

Please note:
* that according to [this StackOverflow comment](https://stackoverflow.com/a/65666899) the AWS declared limit is 63 chars but it supports fewer chars.
* that this edit is backward compatible.

It can be used in this way:
```
DATABASES = {
    'default': {
        'ENGINE': 'djongo',
        [...]
        'MAX_NAME_LENGTH': XX,
    }
}
```

Fix https://github.com/doableware/djongo/issues/595