### PR TITLE
Avoid necessary token skip

### DIFF
--- a/djongo/sql2mongo/operators.py
+++ b/djongo/sql2mongo/operators.py
@@ -412,7 +412,6 @@ class _StatementParser:
 
         elif tok.match(tokens.Keyword, 'BETWEEN'):
             op = BetweenOp(**kw)
-            statement.skip(3)
 
         elif tok.match(tokens.Keyword, 'IS'):
             op = IsOp(**kw)


### PR DESCRIPTION
After parsing the statement and constructing the 'between operator', there is no need to call statement.skip(). 


This bug may cause the query ignores the eq filter when both eq and range filters exist. For example
```
queryset.filter(field_a=xxx).filter(field_b__range=[aaa, bbb])
```
the field_a=xxx may be ignored