### PR TITLE
Bump sqlparse to 0.4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'sqlparse==0.4.2',
+    'sqlparse==0.4.4',
     'pymongo>=3.6.0',
     'django>=2.1',
 ]


### PR DESCRIPTION
Gone through the latest release of sqlparse and seems like nothing is breaking change so we can bump the version to pick the vulnerability fix which is fixed in 0.4.4 https://sqlparse.readthedocs.io/en/latest/changes/