### PR TITLE
ALTER_QUERY::FIXED:: Also rename __schema__ document for renamed collection

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -485,6 +485,16 @@ class AlterQuery(DDLQuery):
 
     def _rename_collection(self):
         self.db[self.left_table].rename(self._new_name)
+        self.db['__schema__'].update_one(
+            {
+                'name': self.left_table
+            },
+            {
+                '$set': {
+                    'name': self._new_name
+                }
+            }
+        )
 
     def _alter(self, statement: SQLStatement):
         self.execute = lambda: None


### PR DESCRIPTION
# Description
When doing a migration including `RenameModel()` operations, collections are correctly reamed, but not their corresponding __schema__ document, resulting in out-of-sync database information for fields and auto-incremental primary IDs

# How to reproduce
1. Create a first migration creating a Model, with at least a primary id, and apply it:
  ```
...
        migrations.CreateModel(
              name='mymodel',
              fields=[
                  ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
              ],
          ),
...
```
2. Check in MongoDB that the model has a corresponding __schema__ document:
```
db.getCollection('__schema__').find({name: {$regex: "mymodel"}})
{ "_id" : ObjectId("65952a1101314dfd724e8d92"), "name" : "test_mymodel", "auto" : { "field_names" : [ "id" ], "seq" : 0 }, "fields" : { "id" : { "type_code" : "int" } } }
```
3. Create a second migration to rename the model, and apply it:
```
...
        migrations.RenameModel(
            old_name="mymodel",
            new_name="mynewmodel",
        )
...
```
4. Check MongoDB's __schema__ collection again, and see that the document "name" value wasn't updated:
```
db.getCollection('__schema__').find({name: {$regex: "mymodel"}})
{ "_id" : ObjectId("65952a1101314dfd724e8d92"), "name" : "test_mymodel", "auto" : { "field_names" : [ "id" ], "seq" : 0 }, "fields" : { "id" : { "type_code" : "int" } } }
```

# Implications
After launching the 2 migrations, __schema__ document is not synced with the latest Model name, so new Model instances are created without the incremental ID value