### PR TITLE
Bump sqlparse version to 0.5.0 and Django 5.0.6

### DIFF
--- a/pkg/requirements.txt
+++ b/pkg/requirements.txt
@@ -1,6 +1,6 @@
-sqlparse==0.2.4
+sqlparse>=0.5.0
 pymongo>=3.2.0
-django>=2.0,<=3.1.4
+django>=5.0.5
 
  # requirements.txt
  #

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -81,9 +81,9 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'sqlparse==0.2.4',
+    'sqlparse>=0.5.0',
     'pymongo>=3.2.0',
-    'django>=2.1',
+    'django>=5.0.6',
     'pytz>=2018.5'
 ]
 


### PR DESCRIPTION
Since the Django version is already updated to 5.0.6 and original djongo has locked the version, that's why need to bump the version 