### PR TITLE
Add support for DriverInfo in MongoClient

### DIFF
--- a/djongo/database.py
+++ b/djongo/database.py
@@ -1,6 +1,11 @@
 from logging import getLogger
 from pymongo import MongoClient
-
+# DriverInfo was added in PyMongo 3.7
+try:
+    from pymongo.driver_info import DriverInfo
+except ImportError:
+    DriverInfo = None
+    
 logger = getLogger(__name__)
 clients = {}
 
@@ -10,6 +15,10 @@ def connect(db, **kwargs):
         return clients[db]
     except KeyError:
         logger.debug('New MongoClient connection')
+        kwargs.setdefault("connect", False)
+        if DriverInfo is not None:
+            import djongo
+            kwargs.setdefault("driver", DriverInfo("djongo", djongo.__version__))
         clients[db] = MongoClient(**kwargs, connect=False)
     return clients[db]
 


### PR DESCRIPTION
This PR will wrap the `MongoClient` creation with [`pymongo.driver_info.DriverInfo`](https://pymongo.readthedocs.io/en/stable/api/pymongo/driver_info.html#pymongo.driver_info.DriverInfo) which makes it easier to filter `mongod` logs for connections that originate from djongo.

For example:

> {"t":{"$date":"2024-06-03T16:10:26.686-04:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn225","msg":"client metadata","attr":{"remote":"127.0.0.1:61857","client":"conn225","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|djongo","version":"3.11.4|1.3.7"},"os":{"type":"Darwin","name":"Darwin","architecture":"x86_64","version":"14.5"},"platform":"CPython 3.10.3.final.0"}}}